### PR TITLE
Delete FluentPVCBinding if it times out without becoming Ready condition

### DIFF
--- a/api/v1alpha1/fluentpvc_types.go
+++ b/api/v1alpha1/fluentpvc_types.go
@@ -102,6 +102,7 @@ const (
 	FluentPVCBindingConditionFinalizerJobSucceeded FluentPVCBindingConditionType = "FinalizerJobSucceeded"
 	FluentPVCBindingConditionFinalizerJobFailed    FluentPVCBindingConditionType = "FinalizerJobFailed"
 	FluentPVCBindingConditionUnknown               FluentPVCBindingConditionType = "Unknown"
+	FluentPVCBindingConditionPodMissing            FluentPVCBindingConditionType = "PodMissing"
 )
 
 type FluentPVCBindingPhase string
@@ -114,6 +115,7 @@ const (
 	FluentPVCBindingPhaseFinalizerJobSucceeded FluentPVCBindingPhase = FluentPVCBindingPhase(FluentPVCBindingConditionFinalizerJobSucceeded)
 	FluentPVCBindingPhaseFinalizerJobFailed    FluentPVCBindingPhase = FluentPVCBindingPhase(FluentPVCBindingConditionFinalizerJobFailed)
 	FluentPVCBindingPhaseUnknown               FluentPVCBindingPhase = FluentPVCBindingPhase(FluentPVCBindingConditionUnknown)
+	FluentPVCBindingPhasePodMissing            FluentPVCBindingPhase = FluentPVCBindingPhase(FluentPVCBindingConditionPodMissing)
 )
 
 // FluentPVCStatus defines the observed state of FluentPVC

--- a/api/v1alpha1/helpers.go
+++ b/api/v1alpha1/helpers.go
@@ -32,6 +32,10 @@ func (b *FluentPVCBinding) IsConditionUnknown() bool {
 	return meta.IsStatusConditionTrue(b.Status.Conditions, string(FluentPVCBindingConditionUnknown))
 }
 
+func (b *FluentPVCBinding) IsConditionPodMissing() bool {
+	return meta.IsStatusConditionTrue(b.Status.Conditions, string(FluentPVCBindingConditionPodMissing))
+}
+
 func (b *FluentPVCBinding) SetConditionReady(reason, message string) {
 	b.setConditionTrue(FluentPVCBindingConditionReady, reason, message)
 }
@@ -54,6 +58,10 @@ func (b *FluentPVCBinding) SetConditionFinalizerJobFailed(reason, message string
 
 func (b *FluentPVCBinding) SetConditionUnknown(reason, message string) {
 	b.setConditionTrue(FluentPVCBindingConditionUnknown, reason, message)
+}
+
+func (b *FluentPVCBinding) SetConditionPodMissing(reason, message string) {
+	b.setConditionTrue(FluentPVCBindingConditionPodMissing, reason, message)
 }
 
 func (b *FluentPVCBinding) SetConditionNotReady(reason, message string) {

--- a/controllers/pvc_controller.go
+++ b/controllers/pvc_controller.go
@@ -47,6 +47,7 @@ func (r *pvcReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	pvc := &corev1.PersistentVolumeClaim{}
 	if err := r.Get(ctx, req.NamespacedName, pvc); err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Info(fmt.Sprintf("Requeue request because pvc='%s' is not found.", req.NamespacedName))
 			return requeueResult(10 * time.Second), nil
 		}
 		return ctrl.Result{}, xerrors.Errorf("Unexpected error occurred.: %w", err)
@@ -54,6 +55,7 @@ func (r *pvcReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.R
 	b := &fluentpvcv1alpha1.FluentPVCBinding{}
 	if err := r.Get(ctx, client.ObjectKey{Namespace: req.Namespace, Name: pvc.Name}, b); err != nil {
 		if apierrors.IsNotFound(err) {
+			logger.Info(fmt.Sprintf("Requeue request because fluentpvcbinding='%s' (namespace='%s') is not found.", pvc.Name, req.Namespace))
 			return requeueResult(10 * time.Second), nil
 		}
 		return ctrl.Result{}, xerrors.Errorf("Unexpected error occurred.: %w", err)


### PR DESCRIPTION
## Which issue(s) this PR fixes:

Fixes #38 

## What this PR does / why we need it:

**Why**
If FluentPVCBinding cannot find the target pod within one hour, it remains in `Unknown` status as an unnecessary resource in Kubernetes cluster. Such unnecessary resources can potentially impact the cluster and operations adversely, so I will modify it to be deleted. I added a process to delete PVC for the same reason.

**Changes**
* Add `PodMissing` condition
* If FluentPVCBinding cannot find the Pod and the FluentPVCBinding does not become the Ready condition within one hour, instead of setting the it to `Unknown` status, it will be deleted.
* When PVC controller detects that FluentPVCBinding has become PodMissing, the PVC will proceed with deletion. Subsequently, FluentPVCBinding controller confirms that the PVC has disappeared and proceeds to delete the FluentPVCBinding.

## How test it:

I have prepared a branch with applied the fixes and the reproduction method, so please check it here.

* https://github.com/R-HNF/fluent-pvc-operator/tree/test-fix-issue38

In addition, I have also made modifications to ensure compatibility with Apple Silicon (arm chip) in the branch. If you're curious about the changes for Apple Silicon, please try the reproduction method on an AMD-based PC.